### PR TITLE
Save s3 message_id and event_time to table

### DIFF
--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -74,6 +74,8 @@ module Bricolage
                 , object_size
                 , schema_name
                 , table_name
+                , message_id
+                , event_time
                 , submit_time
                 )
             select
@@ -81,6 +83,8 @@ module Bricolage
                 , #{obj.size}
                 , schema_name
                 , table_name
+                , #{s obj.message_id}
+                , '#{obj.event_time}' AT TIME ZONE 'JST'
                 , current_timestamp
             from
                 strload_tables

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -4,6 +4,8 @@ CREATE TABLE strload_objects (
   , object_size integer NOT NULL
   , schema_name varchar(128) NOT NULL
   , table_name varchar(128) NOT NULL
+  , message_id varchar(64) NOT NULL
+  , event_time timestamp with time zone NOT NULL
   , submit_time timestamp with time zone NOT NULL
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
 );


### PR DESCRIPTION
Save S3 SQS notification message's id and time to table.
