### PR TITLE
Record duplicated objects to table (instead of ignoring)

### DIFF
--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -74,6 +74,8 @@ module Bricolage
                 , object_size
                 , schema_name
                 , table_name
+                , message_id
+                , event_time
                 , submit_time
                 )
             select
@@ -81,6 +83,8 @@ module Bricolage
                 , #{obj.size}
                 , schema_name
                 , table_name
+                , #{s obj.message_id}
+                , '#{obj.event_time}' AT TIME ZONE 'JST'
                 , current_timestamp
             from
                 strload_tables

--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -59,7 +59,7 @@ module Bricolage
         @ctl_ds.open {|conn|
           conn.transaction {|txn|
             task_ids = insert_tasks(conn)
-            insert_task_object_mappings(conn)
+            insert_task_object_mappings(conn) unless task_ids.empty?
           }
         }
         return task_ids.map {|id| LoadTask.create(task_id: id) }
@@ -112,7 +112,7 @@ module Bricolage
                       , count(*) as object_count
                   from (
                       select
-                          min(object_id)
+                          min(object_id) as object_id
                           , object_url
                           , schema_name
                           , table_name
@@ -169,7 +169,7 @@ module Bricolage
                   , load_batch_size
               from (
                   select
-                      min(object_id)
+                      min(object_id) as object_id
                       , object_url
                       , schema_name
                       , table_name

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -9,4 +9,4 @@ CREATE TABLE strload_objects (
   , submit_time timestamp with time zone NOT NULL
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
 );
-CREATE UNIQUE INDEX strload_objects_object_url ON strload_objects (object_url);
+CREATE INDEX strload_objects_object_url ON strload_objects (object_url);

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -4,6 +4,8 @@ CREATE TABLE strload_objects (
   , object_size integer NOT NULL
   , schema_name varchar(128) NOT NULL
   , table_name varchar(128) NOT NULL
+  , message_id varchar(64) NOT NULL
+  , event_time timestamp with time zone NOT NULL
   , submit_time timestamp with time zone NOT NULL
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
 );

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -2,8 +2,7 @@ CREATE TABLE strload_objects (
   object_id bigserial
   , object_url character varying(512) NOT NULL
   , object_size integer NOT NULL
-  , schema_name varchar(128) NOT NULL
-  , table_name varchar(128) NOT NULL
+  , data_source_id varchar(256) NOT NULL
   , message_id varchar(64) NOT NULL
   , event_time timestamp with time zone NOT NULL
   , submit_time timestamp with time zone NOT NULL


### PR DESCRIPTION
- Save s3 message_id and event_time to table
- Save duplicated objects to strload_objects table for logging
- Insert into strload_task_objects only when new task(s) created
- Save data_source_id to strload_objects table instead of schema_name and table_name
