### PR TITLE
Suppress too much log (each line for s3 notification msg)

### DIFF
--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -68,6 +68,9 @@ module Bricolage
       private
 
       def insert_object(conn, obj)
+        #HACK - suppress log per object
+        log_level = @logger.level
+        @logger.level = Logger::ERROR
         conn.update(<<-EndSQL)
             insert into strload_objects
                 (object_url
@@ -90,6 +93,7 @@ module Bricolage
                 data_source_id = #{s obj.data_source_id}
             ;
         EndSQL
+        @logger.level = log_level
       end
 
       def insert_tasks(conn)


### PR DESCRIPTION
タイトルの通り。
- SQLの実行ログは（もともとバッチ処理を想定しているので）すべてINFOで出力する仕様
- Streaming loaderは1 INSERT / 1 SQS S3 Notification Eventを発行する
- ログが出すぎてディスクがすぐに埋まりそうなので、取り急ぎstrload_objectsへのinsertは出力しないようにする
