### PR TITLE
Improve performance of SQL for task creation

### DIFF
--- a/lib/bricolage/streamingload/objectbuffer.rb
+++ b/lib/bricolage/streamingload/objectbuffer.rb
@@ -111,12 +111,13 @@ module Bricolage
                       select
                           min(object_id) as object_id
                           , object_url
-                          , data_source_id
                       from
                           strload_objects
                       group by
-                          2, 3
+                          object_url
                       ) uniq_objects
+                      inner join strload_objects
+                          using(object_id)
                       left outer join strload_task_objects
                           using(object_id)
                   where


### PR DESCRIPTION
- もとのSQLはstrload_objectsをseq scanするので遅い（100s >)
- strload_objects.object_urlにはindexが張ってある

strload_objectsを舐める部分を、object_urlに張ってあるindexを使うように変更しました
