### PR TITLE
Fixes async delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See LICENSES file for details.
 
 ## Running Test
 
-% rake test
+% bundle exec rake test
 
 ## Author
 

--- a/lib/bricolage/sqsdatasource.rb
+++ b/lib/bricolage/sqsdatasource.rb
@@ -12,14 +12,13 @@ module Bricolage
     declare_type 'sqs'
 
     def initialize(region: 'ap-northeast-1', url:, access_key_id:, secret_access_key:,
-        visibility_timeout:, max_number_of_messages: 10, max_delete_batch_size: 10, wait_time_seconds: 20, noop: false)
+        visibility_timeout:, max_number_of_messages: 10, wait_time_seconds: 20, noop: false)
       @region = region
       @url = url
       @access_key_id = access_key_id
       @secret_access_key = secret_access_key
       @visibility_timeout = visibility_timeout
       @max_number_of_messages = max_number_of_messages
-      @max_delete_batch_size = max_delete_batch_size
       @wait_time_seconds = wait_time_seconds
       @noop = noop
     end
@@ -40,20 +39,21 @@ module Bricolage
     # High-Level Polling Interface
     #
 
-    def main_handler_loop(handlers)
+    def main_handler_loop(handlers:, message_class:)
       trap_signals
 
       n_zero = 0
       until terminating?
         insert_handler_wait(n_zero)
-        n_msg = handle_messages(handlers)
+        n_msg = handle_messages(handlers: handlers, message_class: message_class)
         if n_msg == 0
           n_zero += 1
         else
           n_zero = 0
         end
+        delete_message_buffer.flush
       end
-      @delete_message_buffer.flush if @delete_message_buffer
+      delete_message_buffer.flush_force
       logger.info "shutdown gracefully"
     end
 
@@ -115,8 +115,6 @@ module Bricolage
     def receive_messages
       result = client.receive_message(
         queue_url: @url,
-        attribute_names: ["All"],
-        message_attribute_names: ["All"],
         max_number_of_messages: @max_number_of_messages,
         visibility_timeout: @visibility_timeout,
         wait_time_seconds: @wait_time_seconds
@@ -125,19 +123,18 @@ module Bricolage
     end
 
     def delete_message(msg)
-      # TODO: use batch request?
       client.delete_message(
         queue_url: @url,
         receipt_handle: msg.receipt_handle
       )
     end
 
-    def buffered_delete_message(msg)
+    def delete_message_async(msg)
       delete_message_buffer.put(msg)
     end
 
     def delete_message_buffer
-      @delete_message_buffer ||= DeleteMessageBuffer.new(client, @url, @max_delete_batch_size, logger)
+      @delete_message_buffer ||= DeleteMessageBuffer.new(client, @url, logger)
     end
 
     def put(msg)
@@ -154,60 +151,107 @@ module Bricolage
 
     class DeleteMessageBuffer
 
-      def initialize(sqs_client, url, max_buffer_size, logger)
-        @sqs_client = sqs_client
-        @url = url
-        @max_buffer_size = max_buffer_size
-        @logger = logger
-        @buf = {}
-        @retry_counts = Hash.new(0)
-      end
-
+      BATCH_SIZE_MAX = 10   # SQS system limit
       MAX_RETRY_COUNT = 3
 
+      def initialize(sqs_client, url, logger)
+        @sqs_client = sqs_client
+        @url = url
+        @logger = logger
+        @buf = {}
+      end
+
       def put(msg)
-        @buf[SecureRandom.uuid] = msg
-        flush if size >= @max_buffer_size
+        ent = Entry.new(msg)
+        @buf[ent.id] = ent
+        flush if full?
+      end
+
+      def empty?
+        @buf.empty?
+      end
+
+      def full?
+        @buf.size >= BATCH_SIZE_MAX
       end
 
       def size
         @buf.size
       end
 
-      def flush
-        return unless size > 0
-        response = @sqs_client.delete_message_batch({
-          queue_url: @url,
-          entries: @buf.to_a.map {|item| {id: item[0], receipt_handle: item[1].receipt_handle} }
-        })
-        clear_successes(response.successful)
-        retry_failures(response.failed)
-        @logger.debug "DeleteMessageBatch executed: #{response.successful.size} succeeded, #{response.failed.size} failed."
+      # Flushes all delayed delete requests, including pending requests
+      def flush_force
+        # retry continues in only 2m, now+1h must be after than all @next_issue_time
+        flush(Time.now + 3600)
       end
 
-      private
-
-      def clear_successes(successes)
-        successes.each do |s|
-          @buf.delete s.id
+      def flush(now = Time.now)
+        entries = @buf.values.select {|ent| ent.issurable?(now) }
+        return if entries.empty?
+        @logger.info "flushing async delete requests"
+        entries.each_slice(BATCH_SIZE_MAX) do |ents|
+          res = @sqs_client.delete_message_batch(queue_url: @url, entries: ents.map(&:request_params))
+          @logger.info "DeleteMessageBatch executed: #{res.successful.size} succeeded, #{res.failed.size} failed"
+          issued_time = Time.now
+          res.successful.each do |s|
+            @buf.delete s.id
+          end
+          res.failed.each do |f|
+            ent = @buf[f.id]
+            unless ent
+              @logger.error "[BUG] no corrensponding DeleteMessageBuffer entry: id=#{f.id}"
+              next
+            end
+            ent.failed!(issued_time)
+            if ent.too_many_failure?
+              @logger.warn "DeleteMessage failure count exceeded the limit; give up: message_id=#{ent.message.message_id}, receipt_handle=#{ent.message.receipt_handle}"
+              @buf.delete f.id
+              next
+            end
+            @logger.info "DeleteMessageBatch partially failed (#{ent.n_failure} times): sender_fault=#{f.sender_fault}, code=#{f.code}, message=#{f.message}"
+          end
         end
       end
 
-      def retry_failures(failures)
-        return unless failures.size > 0
-        failures.each do |f|
-          @logger.info "DeleteMessageBatch failed to retry for: id=#{f.id}, sender_fault=#{f.sender_fault}, code=#{f.code}, message=#{f.message}"
+      class Entry
+        def initialize(msg)
+          @message = msg
+          @id = SecureRandom.uuid
+          @n_failure = 0
+          @last_issued_time = nil
+          @next_issue_time = nil
         end
-        flush
-        @buf.keys.map {|k| @retry_counts[k] += 1 }
-        @retry_counts.select {|k, v| v >= MAX_RETRY_COUNT }.each do |k, v|
-          @logger.warn "DeleteMessageBatch failed #{MAX_RETRY_COUNT} times for: message_id=#{@buf[k].message_id}, receipt_handle=#{@buf[k].receipt_handle}"
-          @buf.delete k
-          @retry_counts.delete k
+
+        attr_reader :id
+        attr_reader :message
+        attr_reader :n_failure
+
+        def issurable?(now)
+          @n_failure == 0 or now > @next_issue_time
+        end
+
+        def failed!(issued_time = Time.now)
+          @n_failure += 1
+          @last_issued_time = issued_time
+          @next_issue_time = @last_issued_time + next_retry_interval
+        end
+
+        def next_retry_interval
+          # 16s, 32s, 64s -> total 2m
+          2 ** (3 + @n_failure)
+        end
+
+        def too_many_failure?
+          # (first request) + (3 retry requests) = (4 requests)
+          @n_failure > MAX_RETRY_COUNT
+        end
+
+        def request_params
+          { id: @id, receipt_handle: @message.receipt_handle }
         end
       end
 
-    end # DeleteMessageBuffer
+    end # class DeleteMessageBuffer
 
   end # class SQSDataSource
 

--- a/lib/bricolage/sqsdatasource.rb
+++ b/lib/bricolage/sqsdatasource.rb
@@ -186,7 +186,7 @@ module Bricolage
       end
 
       def flush(now = Time.now)
-        entries = @buf.values.select {|ent| ent.issurable?(now) }
+        entries = @buf.values.select {|ent| ent.issuable?(now) }
         return if entries.empty?
         @logger.info "flushing async delete requests"
         entries.each_slice(BATCH_SIZE_MAX) do |ents|
@@ -226,7 +226,7 @@ module Bricolage
         attr_reader :message
         attr_reader :n_failure
 
-        def issurable?(now)
+        def issuable?(now)
           @n_failure == 0 or now > @next_issue_time
         end
 

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -89,6 +89,7 @@ module Bricolage
         loadtask = load_task(task.id, force: task.force)
         return if loadtask.disabled # skip if disabled, but don't delete sqs msg
         execute_task(loadtask)
+        # Delete load task immediately (do not use async delete)
         @task_queue.delete_message(task)
       end
 

--- a/test/streamingload/test_event.rb
+++ b/test/streamingload/test_event.rb
@@ -5,12 +5,13 @@ module Bricolage::StreamingLoad
 
   class TestEvent < Test::Unit::TestCase
 
-    def new_s3event(message_id: nil, receipt_handle: nil, name: nil, time: nil, region: nil, bucket: nil, key: nil, size: nil)
+    def new_s3event(message_id: nil, receipt_handle: nil, name: nil, time: nil, source: nil, region: nil, bucket: nil, key: nil, size: nil)
       S3ObjectEvent.new(
         message_id: message_id,
         receipt_handle: receipt_handle,
         name: name,
         time: time,
+        source: source,
         region: region,
         bucket: bucket,
         key: key,

--- a/test/test_sqsdatasource.rb
+++ b/test/test_sqsdatasource.rb
@@ -1,0 +1,113 @@
+require 'test/unit'
+require 'bricolage/streamingload/event'
+require 'bricolage/logger'
+
+module Bricolage
+
+  class TestSQSDataSource < Test::Unit::TestCase
+
+    def new_sqs_ds(mock_client = nil)
+      SQSDataSource.new(
+        url: 'http://sqs/000000000000/queue-name',
+        access_key_id: 'access_key_id_1',
+        secret_access_key: 'secret_access_key_1',
+        visibility_timeout: 30
+      ).tap {|ds|
+        logger = NullLogger.new
+        #logger = Bricolage::Logger.default
+        ds.__send__(:initialize_base, 'name', nil, logger)
+        ds.instance_variable_set(:@client, mock_client) if mock_client
+      }
+    end
+
+    class MockSQSClient
+      def initialize(&block)
+        @handler = block
+      end
+
+      def delete_message_batch(**args)
+        @handler.call(args)
+      end
+    end
+
+    class NullLogger
+      def debug(*args) end
+      def info(*args) end
+      def warn(*args) end
+      def error(*args) end
+      def exception(*args) end
+      def with_elapsed_time(*args) yield end
+      def elapsed_time(*args) yield end
+    end
+
+    def sqs_message(seq)
+      MockSQSMessage.new("message_id_#{seq}", "receipt_handle_#{seq}")
+    end
+
+    MockSQSMessage = Struct.new(:message_id, :receipt_handle)
+
+    class MockSQSResponse
+      def initialize(successful: [], failed: [])
+        @successful = successful
+        @failed = failed
+      end
+
+      attr_reader :successful
+      attr_reader :failed
+
+      Success = Struct.new(:id)
+      Failure = Struct.new(:id, :sender_fault, :code, :message)
+
+      def add_success_for(ent)
+        @successful.push Success.new(ent[:id])
+      end
+
+      def add_failure_for(ent)
+        @failed.push Failure.new(ent[:id], true, '400', 'some reason')
+      end
+    end
+
+    test "#delete_message_async" do
+      messages = [sqs_message(0), sqs_message(1), sqs_message(2)]
+      mock = MockSQSClient.new {|args|
+        entries = args[:entries]
+        if entries.size == 3
+          # first time
+          assert_equal messages[0].receipt_handle, entries[0][:receipt_handle]
+          assert_equal messages[1].receipt_handle, entries[1][:receipt_handle]
+          assert_equal messages[2].receipt_handle, entries[2][:receipt_handle]
+          MockSQSResponse.new.tap {|res|
+            res.add_success_for(entries[0])
+            res.add_failure_for(entries[1])
+            res.add_success_for(entries[2])
+          }
+        else
+          # second time
+          MockSQSResponse.new.tap {|res|
+            res.add_success_for(entries[0])
+          }
+        end
+      }
+      ds = new_sqs_ds(mock)
+      ds.delete_message_async(messages[0])
+      ds.delete_message_async(messages[1])
+      ds.delete_message_async(messages[2])
+
+      # first flush
+      flush_time = Time.now
+      ds.delete_message_buffer.flush(flush_time)
+      assert_equal 1, ds.delete_message_buffer.size
+      bufent = ds.delete_message_buffer.instance_variable_get(:@buf).values.first
+      assert_equal 'receipt_handle_1', bufent.message.receipt_handle
+      assert_equal 1, bufent.n_failure
+      assert_false bufent.issurable?(flush_time)
+      assert_true bufent.issurable?(flush_time + 180)
+
+      # second flush
+      ds.delete_message_buffer.flush(flush_time + 180)
+      assert_true ds.delete_message_buffer.empty?
+    end
+
+  end
+
+end

--- a/test/test_sqsdatasource.rb
+++ b/test/test_sqsdatasource.rb
@@ -100,8 +100,8 @@ module Bricolage
       bufent = ds.delete_message_buffer.instance_variable_get(:@buf).values.first
       assert_equal 'receipt_handle_1', bufent.message.receipt_handle
       assert_equal 1, bufent.n_failure
-      assert_false bufent.issurable?(flush_time)
-      assert_true bufent.issurable?(flush_time + 180)
+      assert_false bufent.issuable?(flush_time)
+      assert_true bufent.issuable?(flush_time + 180)
 
       # second flush
       ds.delete_message_buffer.flush(flush_time + 180)


### PR DESCRIPTION
SQSのbatch deleteを以下のような挙動に直します。
- receive 1回ごとに1回flush
- flush時にはバッファにたまっているdeleteリクエストをすべて処理する
- ただし一度エラーになったリクエストは待ち時間を設定し、その時間が来るまで処理しない。リトライまでの待ち時間は徐々にのばす。
  - 最大リトライ回数は3回で、16秒〜64秒。合計で2分弱くらいの想定
  - 最短のvisibility timeoutが3分くらいだろうと考えて、それ以上はやらない
- シャットダウン時のflushはインターバルを無視してすべて処理する

@shimpeko おねがいします。
