### PR TITLE
Alert on error

### DIFF
--- a/lib/bricolage/streamingload/alertinglogger.rb
+++ b/lib/bricolage/streamingload/alertinglogger.rb
@@ -9,6 +9,9 @@ module Bricolage
         @sns_logger.level = Kernel.const_get("Logger").const_get(alert_level.upcase)
       end
 
+      def_delegator '@logger', :level
+      def_delegator '@logger', :level=
+
       %w(log debug info warn error fatal unknown).each do |m|
         define_method(m) do |*args|
           [@logger, @sns_logger].map {|t| t.send(m, *args) }

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -56,6 +56,9 @@ module Bricolage
         create_pid_file opts.pid_file_path if opts.pid_file_path
         dispatcher.set_dispatch_timer
         dispatcher.event_loop
+      rescue Exception => e
+        alert_logger.error e.message
+        raise
       end
 
       def Dispatcher.new_logger(path, config)

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -120,6 +120,7 @@ module Bricolage
 
       def write_job_error(status, message)
         @end_time = Time.now
+        @logger.warn message.lines.first
         write_job_result status, message.lines.first.strip[0, MAX_MESSAGE_LENGTH]
       end
 

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -49,6 +49,9 @@ module Bricolage
           create_pid_file opts.pid_file_path if opts.pid_file_path
           service.event_loop
         end
+      rescue Exception => e
+        alert_logger.error e.message
+        raise
       end
 
       def LoaderService.new_logger(path, config)


### PR DESCRIPTION
例外発生をloggerで記録していなかったので、alert loggerが活躍する機会（warnより重いログが記録されること）が無かったです。

どこでどうやって例外をloggerに渡すか迷いましたが、取りこぼしがあると困るので一番上でcatchして渡すことにしました。

@aamine お願いします
