### PR TITLE
New event: flushtable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bricolage-streamingload (0.1.0)
+    bricolage-streamingload (0.4.0)
       aws-sdk (~> 2)
       bricolage (= 5.16.8)
       pg
@@ -9,12 +9,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (2.3.15)
-      aws-sdk-resources (= 2.3.15)
-    aws-sdk-core (2.3.15)
+    aws-sdk (2.5.1)
+      aws-sdk-resources (= 2.5.1)
+    aws-sdk-core (2.5.1)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.3.15)
-      aws-sdk-core (= 2.3.15)
+    aws-sdk-resources (2.5.1)
+      aws-sdk-core (= 2.5.1)
     bricolage (5.16.8)
       aws-sdk (~> 2)
       mysql2
@@ -26,10 +26,8 @@ GEM
       msgpack (>= 0.4.4, < 0.6.0, != 0.5.3, != 0.5.2, != 0.5.1, != 0.5.0)
     hirb (0.7.3)
     httpclient (2.8.0)
-    jmespath (1.2.4)
-      json_pure (>= 1.8.1)
+    jmespath (1.3.1)
     json (1.8.3)
-    json_pure (1.8.3)
     method_source (0.8.2)
     msgpack (0.5.12)
     mysql2 (0.4.4)

--- a/lib/bricolage/streamingload/event.rb
+++ b/lib/bricolage/streamingload/event.rb
@@ -10,7 +10,7 @@ module Bricolage
         case
         when rec['eventName'] == 'shutdown' then ShutdownEvent
         when rec['eventName'] == 'dispatch' then DispatchEvent
-        when rec['eventName'] == 'flush' then FlushEvent
+        when rec['eventName'] == 'flushtable' then FlushTableEvent
         when rec['eventName'] == 'checkpoint' then CheckPointEvent
         when rec['eventSource'] == 'aws:s3'
           S3ObjectEvent
@@ -67,13 +67,13 @@ module Bricolage
     end
 
 
-    class FlushEvent < Event
+    class FlushTableEvent < Event
 
-      def FlushEvent.create(delay_seconds:, table_name:)
-        super name: 'flush', delay_seconds: delay_seconds, table_name: table_name
+      def FlushTableEvent.create(table_name:)
+        super name: 'flushtable', table_name: table_name
       end
 
-      def FlushEvent.parse_sqs_record(msg, rec)
+      def FlushTableEvent.parse_sqs_record(msg, rec)
         {
           table_name: rec['tableName']
         }

--- a/test/streamingload/test_dispatcher.rb
+++ b/test/streamingload/test_dispatcher.rb
@@ -69,6 +69,7 @@ module Bricolage
 
         # Event Queue Call Sequence
         hst = event_queue.client.call_history
+        assert_equal 6, hst.size
         assert_equal :send_message, hst[0].name      # start flush timer
         assert_equal :receive_message, hst[1].name
         assert_equal :delete_message_batch, hst[2].name
@@ -78,6 +79,7 @@ module Bricolage
 
         # Task Queue Call Sequence
         hst = task_queue.client.call_history
+        assert_equal 1, hst.size
         assert_equal :send_message, hst[0].name
         assert(/streaming_load_v3/ =~ hst[0].args[:message_body])
         task_id = JSON.load(hst[0].args[:message_body])['Records'][0]['taskId'].to_i
@@ -100,6 +102,100 @@ module Bricolage
                   strload_objects
               where
                   object_id not in (select object_id from strload_task_objects)
+              ;
+          EndSQL
+        }
+      end
+
+      test "flushtable event" do
+        ctx = Context.for_application('.', environment: 'test', logger: NullLogger.new)
+        ctl_ds = ctx.get_data_source('sql', 'dwhctl')
+
+        event_queue = SQSDataSource.new_mock(queue: [
+          # 1st ReceiveMessage
+          [
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.aaa/datafile-0001.json.gz'),
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.bbb/datafile-0001.json.gz'),
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.ccc/datafile-0002.json.gz'),
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.aaa/datafile-0002.json.gz'),
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.bbb/datafile-0003.json.gz'),
+            SQSMock::Message.s3_object_created_event('s3://test-bucket/testschema.ccc/datafile-0003.json.gz'),
+            SQSMock::Message.new(body: {eventSource: 'bricolage:system', eventName: 'flushtable', tableName: 'testschema.bbb'}),
+            SQSMock::Message.new(body: {eventSource: 'bricolage:system', eventName: 'shutdown'})
+          ]
+        ])
+
+        task_queue = SQSDataSource.new_mock
+
+        object_buffer = ObjectBuffer.new(
+          control_data_source: ctl_ds,
+          logger: ctx.logger
+        )
+
+        url_patterns = URLPatterns.for_config([
+          {
+            "url" => %r<\As3://test-bucket/testschema\.(?<table>\w+)/datafile-\d{4}\.json\.gz>.source,
+            "schema" => 'testschema',
+            "table" => '%table'
+          }
+        ])
+
+        dispatcher = Dispatcher.new(
+          event_queue: event_queue,
+          task_queue: task_queue,
+          object_buffer: object_buffer,
+          url_patterns: url_patterns,
+          dispatch_interval: 600,
+          logger: ctx.logger
+        )
+
+        # FIXME: database cleaner
+        ctl_ds.open {|conn|
+          conn.update("truncate strload_tables")
+          conn.update("truncate strload_objects")
+          conn.update("truncate strload_task_objects")
+          conn.update("truncate strload_tasks")
+          conn.update("insert into strload_tables values ('testschema', 'aaa', 'testschema.aaa', 100, 1800, false)")
+          conn.update("insert into strload_tables values ('testschema', 'bbb', 'testschema.bbb', 100, 1800, false)")
+          conn.update("insert into strload_tables values ('testschema', 'ccc', 'testschema.ccc', 100, 1800, false)")
+        }
+        dispatcher.event_loop
+
+        # Event Queue Call Sequence
+        hst = event_queue.client.call_history
+        assert_equal 5, hst.size
+        assert_equal :send_message, hst[0].name      # start dispatch timer
+        assert_equal :receive_message, hst[1].name
+        assert_equal :delete_message, hst[2].name    # delete flushtable event
+        assert_equal :delete_message, hst[3].name    # delete shutdown event
+        assert_equal :delete_message_batch, hst[4].name
+
+        # Task Queue Call Sequence
+        hst = task_queue.client.call_history
+        assert_equal 1, hst.size
+        assert_equal :send_message, hst[0].name
+        assert(/streaming_load_v3/ =~ hst[0].args[:message_body])
+        task_id = JSON.load(hst[0].args[:message_body])['Records'][0]['taskId'].to_i
+        assert_not_equal 0, task_id
+
+        # Object Buffer
+        assert_equal [], unassigned_table_objects(ctl_ds, 'testschema.bbb')
+        task = ctl_ds.open {|conn| LoadTask.load(conn, task_id) }
+        assert_equal 'testschema', task.schema
+        assert_equal 'bbb', task.table
+        assert_equal 2, task.object_urls.size
+      end
+
+      def unassigned_table_objects(ctl_ds, table_name)
+        ctl_ds.open {|conn|
+          conn.query_values(<<-EndSQL)
+              select
+                  object_url
+              from
+                  strload_objects
+              where
+                  data_source_id = '#{table_name}'
+                  and object_id not in (select object_id from strload_task_objects)
               ;
           EndSQL
         }


### PR DESCRIPTION
新しいイベントflushtableを追加します。

flushtableイベントは特定のテーブルについて、条件なしに即座にバッファ内のオブジェクトをすべて掃き出してロードタスク化します。

このイベントは手動のテーブルメンテ（例えばデータ入れ直し）で使うことを想定しています。メンテをするのに最も都合のいい状況は、特定のテーブルの未処理オブジェクトはすべてpreprocのキューに残り、処理が始まってしまった（preprocキューからreceiveされた）オブジェクトはすべてロードまで完了して、streaming loadパイプラインからなくなった状態です。flushtableイベントはその状況を最短時間で作るために使用できます。

※ flushtableイベントを使うとdispatcherは即座に通過させられるが、loaderも抜けるまでにはかなり時間が必要かもしれない。しかしloaderを優先通過させるにはpriority queueが必要になり、SQSで実装するにはキューを複数用意することになりそう。
