### PR TITLE
Fix undefined method error

### DIFF
--- a/lib/bricolage/streamingload/alertinglogger.rb
+++ b/lib/bricolage/streamingload/alertinglogger.rb
@@ -9,14 +9,14 @@ module Bricolage
         @sns_logger.level = Kernel.const_get("Logger").const_get(alert_level.upcase)
       end
 
-      def_delegator '@logger', :level
-      def_delegator '@logger', :level=
+      def_delegators '@logger', :level, :level=, :debug?, :info?, :warn?, :error?, :fatal?, :unknown?
 
       %w(log debug info warn error fatal unknown).each do |m|
         define_method(m) do |*args|
           [@logger, @sns_logger].map {|t| t.send(m, *args) }
         end
       end
+
     end
   end
 end

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -78,6 +78,8 @@ module Bricolage
         @logger = logger
       end
 
+      attr_reader :logger
+
       def event_loop
         @task_queue.handle_messages(handler: self, message_class: Task)
         @logger.info "shutdown gracefully"


### PR DESCRIPTION
Fix 2 errors.

1

```
P777:dwh-streaming-load shimpei-kodama$ be bricolage-streaming-loader config/streamingload.yml
bundler: failed to load command: bricolage-streaming-loader (/Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader)
NameError: undefined local variable or method `logger' for Bricolage::StreamingLoad::LoaderService:Class
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:81:in `<class:LoaderService>'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:14:in `<module:StreamingLoad>'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:12:in `<module:Bricolage>'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:10:in `<top (required)>'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/bin/bricolage-streaming-loader:4:in `require'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/bin/bricolage-streaming-loader:4:in `<top (required)>'
  /Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader:23:in `load'
  /Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader:23:in `<top (required)>'
```

2

```
P777:dwh-streaming-load shimpei-kodama$ be bricolage-streaming-loader config/streamingload.yml
2016-08-17 16:19:34 +0900: DEBUG: receive_message({:queue_url=>"https://sqs.ap-northeast-1.amazonaws.com/789035092620/bricolage-load-tasks-dev", :max_number_of_messages=>1, :visibility_timeout=>180, :wait_time_seconds=>20})
2016-08-17 16:19:34 +0900: INFO: receive 1 messages
2016-08-17 16:19:35 +0900: ERROR: undefined method `debug?' for #<Bricolage::StreamingLoad::AlertingLogger:0x007f7fb49bab50>
bundler: failed to load command: bricolage-streaming-loader (/Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader)
NoMethodError: undefined method `debug?' for #<Bricolage::StreamingLoad::AlertingLogger:0x007f7fb49bab50>
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:114:in `handle'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:51:in `block (2 levels) in handle_messages'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:50:in `each'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:50:in `block in handle_messages'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:82:in `polling_loop'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/sqsdatasource.rb:47:in `handle_messages'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:84:in `event_loop'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/lib/bricolage/streamingload/loaderservice.rb:50:in `main'
  /Users/shimpei-kodama/repos/bricolage-streaming-loader/bin/bricolage-streaming-loader:6:in `<top (required)>'
  /Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader:23:in `load'
  /Users/shimpei-kodama/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bin/bricolage-streaming-loader:23:in `<top (required)>'
```

@aamine please review
