### PR TITLE
Add loaded flag to strload_objects

### DIFF
--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -115,7 +115,7 @@ module Bricolage
         @end_time = Time.now
         @ctl_ds.open {|conn|
           conn.transaction {
-            write_job_result conn 'success', ''
+            write_job_result conn, 'success', ''
             update_loaded_flag conn
           }
         }
@@ -133,7 +133,7 @@ module Bricolage
                     object_id
                 from
                     strload_task_objects
-                where task_id = (select task_id from strload_jobs where job_id #{@job_id})
+                where task_id = (select task_id from strload_jobs where job_id = #{@job_id})
               )
           ;
         EndSQL

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -6,6 +6,7 @@ CREATE TABLE strload_objects (
   , message_id varchar(64) NOT NULL
   , event_time timestamp with time zone NOT NULL
   , submit_time timestamp with time zone NOT NULL
+  , loaded boolean DEFAULT false
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
 );
 CREATE INDEX strload_objects_object_url ON strload_objects (object_url);


### PR DESCRIPTION
strload_objectsにloaded flagを追加し、load完了時点でtrueにセットします。

万が一メタデータに不整合が生じた場合もでも、オブジェクトがロードがロード済みがどうかを判定出来るようにするための予防的な施策です。

@aamine plz comment while it's still wip
