### PR TITLE
[fix] chdir to working directory just before starting each load tasks

### DIFF
--- a/lib/bricolage/streamingload/alertinglogger.rb
+++ b/lib/bricolage/streamingload/alertinglogger.rb
@@ -1,19 +1,37 @@
+require 'bricolage/logger'
+require 'logger'
+require 'forwardable'
+
 module Bricolage
   module StreamingLoad
     class AlertingLogger
       extend Forwardable
 
-      def initialize(logger: , sns_datasource: , alert_level: 'warn')
+      def initialize(logger:, sns_datasource:, alert_level: 'warn')
         @logger = logger
-        @sns_logger = Bricolage::Logger.new(device: sns_datasource)
-        @sns_logger.level = Kernel.const_get("Logger").const_get(alert_level.upcase)
+        @alerter = Bricolage::Logger.new(device: sns_datasource)
+        @alerter.level = ::Logger.const_get(alert_level.upcase)
       end
 
       def_delegators '@logger', :level, :level=, :debug?, :info?, :warn?, :error?, :fatal?, :unknown?
 
-      %w(log debug info warn error fatal unknown).each do |m|
+      %w[log debug info warn error fatal unknown].each do |m|
         define_method(m) do |*args|
-          [@logger, @sns_logger].map {|t| t.send(m, *args) }
+          @logger.__send__(m, *args)
+          begin
+            @alerter.__send__(m, *args)
+          rescue Exception => err
+            @logger.error "could not send alert: #{err.message}"
+          end
+        end
+      end
+
+      def exception(ex)
+        @logger.exception(ex)
+        begin
+          @alerter.error(ex.message)
+        rescue Exception => err
+          @logger.error "could not send alert: #{err.message}"
         end
       end
 

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -29,16 +29,16 @@ module Bricolage
         config = YAML.load(File.read(config_path))
         logger = opts.log_file_path ? new_logger(opts.log_file_path, config) : nil
         ctx = Context.for_application('.', environment: opts.environment, logger: logger)
-        event_queue = ctx.get_data_source('sqs', config.fetch('event-queue-ds'))
-        task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds'))
+        event_queue = ctx.get_data_source('sqs', config.fetch('event-queue-ds', 'sqs_event'))
+        task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds', 'sqs_task'))
         alert_logger = AlertingLogger.new(
           logger: ctx.logger,
-          sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds')),
+          sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds', 'sns')),
           alert_level: config.fetch('alert-level', 'warn')
         )
 
         object_buffer = ObjectBuffer.new(
-          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds')),
+          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds', 'db_data')),
           logger: alert_logger
         )
 

--- a/lib/bricolage/streamingload/loader.rb
+++ b/lib/bricolage/streamingload/loader.rb
@@ -51,7 +51,7 @@ module Bricolage
                 strload_tasks
             where
                 task_id = #{@params.task_id}
-                and (task_id not in (select task_id from strload_jobs) or #{@params.force})
+                and (#{@params.force?} or task_id not in (select task_id from strload_jobs))
             returning job_id
             ;
           EndSQL

--- a/lib/bricolage/streamingload/loaderparams.rb
+++ b/lib/bricolage/streamingload/loaderparams.rb
@@ -1,3 +1,4 @@
+require 'bricolage/job'
 require 'bricolage/rubyjobclass'
 require 'bricolage/psqldatasource'
 
@@ -60,8 +61,8 @@ module Bricolage
         @task.table
       end
 
-      def force
-        @task.force
+      def force?
+        @task.force?
       end
 
       def object_urls

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -26,20 +26,20 @@ module Bricolage
         config = YAML.load(File.read(config_path))
         logger = opts.log_file_path ? new_logger(opts.log_file_path, config) : nil
         ctx = Context.for_application(opts.working_dir, environment: opts.environment, logger: logger)
-        redshift_ds = ctx.get_data_source('sql', config.fetch('redshift-ds'))
-        task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds'))
+        redshift_ds = ctx.get_data_source('sql', config.fetch('redshift-ds', 'db_data'))
+        task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds', 'sqs_task'))
         raw_logger = logger = ctx.logger
         if config.key?('alert-level')
           logger = AlertingLogger.new(
             logger: raw_logger,
-            sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds')),
+            sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds', 'sns')),
             alert_level: config.fetch('alert-level', 'warn')
           )
         end
 
         service = new(
           context: ctx,
-          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds')),
+          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds', 'db_ctl')),
           data_source: redshift_ds,
           task_queue: task_queue,
           working_dir: opts.working_dir,

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -1,3 +1,4 @@
+require 'bricolage/context'
 require 'bricolage/sqsdatasource'
 require 'bricolage/streamingload/task'
 require 'bricolage/streamingload/loader'
@@ -5,6 +6,7 @@ require 'bricolage/streamingload/alertinglogger'
 require 'bricolage/logger'
 require 'bricolage/exception'
 require 'bricolage/version'
+require 'yaml'
 require 'optparse'
 
 module Bricolage
@@ -23,21 +25,25 @@ module Bricolage
         config_path, * = opts.rest_arguments
         config = YAML.load(File.read(config_path))
         logger = opts.log_file_path ? new_logger(opts.log_file_path, config) : nil
-        ctx = Context.for_application('.', environment: opts.environment, logger: logger)
+        ctx = Context.for_application(opts.working_dir, environment: opts.environment, logger: logger)
         redshift_ds = ctx.get_data_source('sql', config.fetch('redshift-ds'))
         task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds'))
-        alert_logger = AlertingLogger.new(
-          logger: ctx.logger,
-          sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds')),
-          alert_level: config.fetch('alert-level', 'warn')
-        )
+        raw_logger = logger = ctx.logger
+        if config.key?('alert-level')
+          logger = AlertingLogger.new(
+            logger: raw_logger,
+            sns_datasource: ctx.get_data_source('sns', config.fetch('sns-ds')),
+            alert_level: config.fetch('alert-level', 'warn')
+          )
+        end
 
         service = new(
           context: ctx,
           control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds')),
           data_source: redshift_ds,
           task_queue: task_queue,
-          logger: alert_logger
+          working_dir: opts.working_dir,
+          logger: logger
         )
 
         if opts.task_id
@@ -46,12 +52,18 @@ module Bricolage
         else
           # Server mode
           Process.daemon(true) if opts.daemon?
+          Dir.chdir '/'
           create_pid_file opts.pid_file_path if opts.pid_file_path
-          service.event_loop
+          begin
+            logger.info "*** bricolage-streaming-loader started: pid=#{$$}"
+            service.event_loop
+            logger.info "*** bricolage-streaming-loader shutdown gracefully: pid=#{$$}"
+          rescue Exception => ex
+            logger.exception(ex)
+            logger.error "*** bricolage-streaming-loader abort: pid=#{$$}"
+            raise
+          end
         end
-      rescue Exception => e
-        alert_logger.error e.message
-        raise
       end
 
       def LoaderService.new_logger(path, config)
@@ -70,20 +82,19 @@ module Bricolage
         # ignore
       end
 
-      def initialize(context:, control_data_source:, data_source:, task_queue:, logger:)
+      def initialize(context:, control_data_source:, data_source:, task_queue:, working_dir:, logger:)
         @ctx = context
         @ctl_ds = control_data_source
         @ds = data_source
         @task_queue = task_queue
+        @working_dir = working_dir
         @logger = logger
       end
 
       attr_reader :logger
 
       def event_loop
-        @logger.info "loader started"
         @task_queue.handle_messages(handler: self, message_class: Task)
-        @logger.info "shutdown gracefully"
       end
 
       def execute_task_by_id(task_id)
@@ -96,19 +107,19 @@ module Bricolage
 
       # message handler
       def handle_streaming_load_v3(task)
-        # 1. Load task detail from table
-        # 2. Skip disabled (sqs message should not have disabled state since it will never be exectuted)
-        # 3. Try execute
-        #   - Skip if the task has already been executed AND force = false
-        loadtask = load_task(task.id, force: task.force)
-        @logger.info "handling load task: task_id=#{task.id}"
-        if loadtask.disabled
-          @logger.info "skip disabled task: task_id=#{task.id}"
-          return
-        end
-        execute_task(loadtask)
-        # Delete load task immediately (do not use async delete)
-        @task_queue.delete_message(task)
+        Dir.chdir(@working_dir) {
+          loadtask = load_task(task.id, force: task.force?)
+          if loadtask.disabled
+            # Skip if disabled, and don't delete SQS message.
+            @logger.info "skip disabled task: task_id=#{task.id}"
+            return
+          end
+          execute_task(loadtask)
+          # Do not use async delete
+          @task_queue.delete_message(task)
+        }
+      rescue => ex
+        @logger.exception ex
       end
 
       def execute_task(task)
@@ -124,16 +135,18 @@ module Bricolage
       def initialize(argv)
         @argv = argv
         @task_id = nil
+        @environment = Context::DEFAULT_ENV
         @daemon = false
         @log_file_path = nil
         @pid_file_path = nil
+        @working_dir = Dir.getwd
         @rest_arguments = nil
 
         @opts = opts = OptionParser.new("Usage: #{$0} CONFIG_PATH")
         opts.on('--task-id=ID', 'Execute oneshot load task (implicitly disables daemon mode).') {|task_id|
           @task_id = task_id
         }
-        opts.on('-e', '--environment=NAME', "Sets execution environment [default: #{Context::DEFAULT_ENV}]") {|env|
+        opts.on('-e', '--environment=NAME', "Sets execution environment [default: #{@environment}]") {|env|
           @environment = env
         }
         opts.on('--daemon', 'Becomes daemon in server mode.') {
@@ -144,6 +157,9 @@ module Bricolage
         }
         opts.on('--pid-file=PATH', 'Creates PID file.') {|path|
           @pid_file_path = path
+        }
+        opts.on('--working-dir=PATH', "Loader working directory. [default: #{@working_dir}]") {|path|
+          @working_dir = path
         }
         opts.on('--help', 'Prints this message and quit.') {
           puts opts.help
@@ -166,14 +182,18 @@ module Bricolage
         raise OptionError, err.message
       end
 
-      attr_reader :rest_arguments, :environment, :log_file_path
+      attr_reader :rest_arguments
+
       attr_reader :task_id
+      attr_reader :environment
 
       def daemon?
         @daemon
       end
 
+      attr_reader :log_file_path
       attr_reader :pid_file_path
+      attr_reader :working_dir
 
     end
 

--- a/lib/bricolage/streamingload/task.rb
+++ b/lib/bricolage/streamingload/task.rb
@@ -35,7 +35,7 @@ module Bricolage
       def LoadTask.parse_sqs_record(msg, rec)
         {
           task_id: rec['taskId'],
-          force: rec['force'],
+          force: (rec['force'].to_s == 'true')
         }
       end
 
@@ -94,7 +94,11 @@ module Bricolage
         @disabled = disabled
       end
 
-      attr_reader :id, :force
+      attr_reader :id
+
+      def force?
+        !!@force
+      end
 
       #
       # For writer only


### PR DESCRIPTION
Capistranoでデプロイしていても（デプロイごとに別のディレクトリができても）ジョブの変更がすぐ反映されるように、ロードの開始ごとにchdirしなおすようにした。loaderに--working-dirオプションをつけると、指定したパスにchdirする。

ついでにいくつか改善
- ロードエラーをイベントハンドラ内でrescue（プロセスごと落とさない）
- configのデータソース名（redshift-dsとか）にデフォルト値をつけた
