### PR TITLE
Improve performance of task generation

### DIFF
--- a/schema/strload_dup_objects.ct
+++ b/schema/strload_dup_objects.ct
@@ -1,0 +1,8 @@
+CREATE TABLE strload_dup_objects (
+  object_url character varying(512) NOT NULL
+  , object_size integer NOT NULL
+  , data_source_id varchar(256) NOT NULL
+  , message_id varchar(64) NOT NULL
+  , event_time timestamp with time zone NOT NULL
+  , submit_time timestamp with time zone NOT NULL
+);

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -8,5 +8,5 @@ CREATE TABLE strload_objects (
   , submit_time timestamp with time zone NOT NULL
   , loaded boolean DEFAULT false
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
+  , CONSTRAINT strload_objects_object_url UNIQUE (object_url)
 );
-CREATE INDEX strload_objects_object_url ON strload_objects (object_url);

--- a/schema/strload_objects.ct
+++ b/schema/strload_objects.ct
@@ -10,3 +10,4 @@ CREATE TABLE strload_objects (
   , CONSTRAINT strload_objects_pkey PRIMARY KEY (object_id)
   , CONSTRAINT strload_objects_object_url UNIQUE (object_url)
 );
+CREATE INDEX strload_objects_data_source_id ON strload_objects (data_source_id);

--- a/schema/strload_tasks.ct
+++ b/schema/strload_tasks.ct
@@ -7,3 +7,4 @@ CREATE TABLE strload_tasks (
   , CONSTRAINT strload_tasks_pkey PRIMARY KEY (task_id)
 )
 ;
+CREATE INDEX strload_tasks_schema_table ON strload_tasks (schema_name, table_name);

--- a/utils/init_strload_tables.sql
+++ b/utils/init_strload_tables.sql
@@ -1,9 +1,11 @@
 drop table if exists strload_objects cascade;
+drop table if exists strload_dup_objects cascade;
 drop table if exists strload_task_objects;
 drop table if exists strload_tasks cascade;
 drop table if exists strload_jobs cascade;
 
 \i schema/strload_objects.ct
+\i schema/strload_dup_objects.ct
 \i schema/strload_task_objects.ct
 \i schema/strload_tasks.ct
 \i schema/strload_jobs.ct


### PR DESCRIPTION
- [x] strload_objectsをobject_urlについて一意にする
- [x] strload_objectsへのinsert時にstrload_tasks_objectsにtask_id = -1のレコードを追加する
- [x] ↑のテーブルを使ってtaskを詰めるようにする
