### PR TITLE
Detect S3 events by "s3" attribute instead of "eventSource" attribute

### DIFF
--- a/lib/bricolage/streamingload/event.rb
+++ b/lib/bricolage/streamingload/event.rb
@@ -12,7 +12,7 @@ module Bricolage
         when rec['eventName'] == 'dispatch' then DispatchEvent
         when rec['eventName'] == 'flushtable' then FlushTableEvent
         when rec['eventName'] == 'checkpoint' then CheckPointEvent
-        when rec['eventSource'] == 'aws:s3'
+        when !!rec['s3']
           S3ObjectEvent
         else
           raise "[FATAL] unknown SQS message record: eventSource=#{rec['eventSource']} event=#{rec['eventName']} message_id=#{msg.message_id}"


### PR DESCRIPTION
S3オブジェクト関係のイベントかどうかを判定するために、eventSourceではなくs3属性が存在するかどうかで判定するようにします。

preprocで疑似的にS3イベントを生成したいが、eventSource: "aws:s3" にしてしまうと、本当にS3から来たのか生成したのか区別する手段がなくなる気がするので……

@shimpeko 
