### PR TITLE
Handles unknown SQS messages softly

### DIFF
--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -41,7 +41,7 @@ module Bricolage
         end
 
         object_buffer = ObjectBuffer.new(
-          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds', 'db_data')),
+          control_data_source: ctx.get_data_source('sql', config.fetch('ctl-postgres-ds', 'db_ctl')),
           logger: logger
         )
 

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -115,6 +115,11 @@ module Bricolage
         end
       end
 
+      def handle_unknown(e)
+        logger.warn "unknown event: #{e.message_body}"
+        @event_queue.delete_message_async(e)
+      end
+
       def handle_shutdown(e)
         @event_queue.initiate_terminate
         # Delete this event immediately

--- a/lib/bricolage/streamingload/event.rb
+++ b/lib/bricolage/streamingload/event.rb
@@ -12,10 +12,8 @@ module Bricolage
         when rec['eventName'] == 'dispatch' then DispatchEvent
         when rec['eventName'] == 'flushtable' then FlushTableEvent
         when rec['eventName'] == 'checkpoint' then CheckPointEvent
-        when !!rec['s3']
-          S3ObjectEvent
-        else
-          raise "[FATAL] unknown SQS message record: eventSource=#{rec['eventSource']} event=#{rec['eventName']} message_id=#{msg.message_id}"
+        when !!rec['s3'] then S3ObjectEvent
+        else UnknownSQSMessage
         end
       end
 

--- a/lib/bricolage/streamingload/loaderservice.rb
+++ b/lib/bricolage/streamingload/loaderservice.rb
@@ -106,6 +106,12 @@ module Bricolage
       end
 
       # message handler
+      def handle_unknown(task)
+        @logger.warn "unknown task: #{task.message_body}"
+        @task_queue.delete_message task
+      end
+
+      # message handler
       def handle_streaming_load_v3(task)
         Dir.chdir(@working_dir) {
           loadtask = load_task(task.id, force: task.force?)

--- a/lib/bricolage/streamingload/task.rb
+++ b/lib/bricolage/streamingload/task.rb
@@ -10,8 +10,7 @@ module Bricolage
       def Task.get_concrete_class(msg, rec)
         case
         when rec['eventName'] == 'streaming_load_v3' then LoadTask
-        else
-          raise "[FATAL] unknown SQS message record: eventSource=#{rec['eventSource']} event=#{rec['eventName']} message_id=#{msg.message_id}"
+        else UnknownSQSMessage
         end
       end
 


### PR DESCRIPTION
RecordsがないSQSメッセージや、パースできないSQSメッセージは無視するでも例外でもなく、警告してちゃんと消すようにした。

ついでに以下を改善
- SNS通知を設定しないと動かなくなってて開発がめどいので省略可能にした
- ログ出力をさらに追加

@shimpeko 
