### PR TITLE
[new] Automatically complement strload_jobs status

### DIFF
--- a/lib/bricolage/streamingload/taskhandler.rb
+++ b/lib/bricolage/streamingload/taskhandler.rb
@@ -29,6 +29,7 @@ module Bricolage
         ctx = Context.for_application(opts.working_dir, environment: opts.environment, logger: logger)
 
         ctl_ds = ctx.get_data_source('sql', config.fetch('ctl-postgres-ds', 'db_ctl'))
+        data_ds = ctx.get_data_source('sql', config.fetch('redshift-ds', 'db_data'))
         task_queue = ctx.get_data_source('sqs', config.fetch('task-queue-ds', 'sqs_task'))
         log_table = config.fetch('log-table', 'strload_load_logs')
         service_logger =
@@ -41,6 +42,7 @@ module Bricolage
         task_handler = new(
           context: ctx,
           ctl_ds: ctl_ds,
+          data_ds: data_ds,
           log_table: log_table,
           task_queue: task_queue,
           working_dir: opts.working_dir,
@@ -92,9 +94,10 @@ module Bricolage
         # ignore
       end
 
-      def initialize(context:, ctl_ds:, log_table:, task_queue:, working_dir:, logger:, job_class: Job)
+      def initialize(context:, ctl_ds:, data_ds:, log_table:, task_queue:, working_dir:, logger:, job_class: Job)
         @ctx = context
         @ctl_ds = ctl_ds
+        @data_ds = data_ds
         @log_table = log_table
         @task_queue = task_queue
         @working_dir = working_dir
@@ -132,7 +135,7 @@ module Bricolage
       end
 
       def new_job(task_id, force)
-        @job_class.new(context: @ctx, ctl_ds: @ctl_ds, log_table: @log_table, task_id: task_id, force: force, logger: @logger)
+        @job_class.new(context: @ctx, ctl_ds: @ctl_ds, data_ds: data_ds, log_table: @log_table, task_id: task_id, force: force, logger: @logger)
       end
 
       def job_class

--- a/test/streamingload/test_job.rb
+++ b/test/streamingload/test_job.rb
@@ -564,7 +564,27 @@ module Bricolage
         end
       end
 
-    end
+      test "TaskInfo#failure_count" do
+        test_data = [
+          [%w[], 0],
+          [%w[success], 0],
+          [%w[failure], 1],
+          [%w[error], 1],
+          [%w[failure failure], 2],
+          [%w[failure error], 2],
+          [%w[failure success], 0],
+          [%w[success success], 0],
+          [%w[failure success failure], 1],
+          [%w[failure success failure success failure failure], 2]
+        ]
+        c = Job::ControlConnection
+        test_data.each do |status_list, expected_count|
+          task = c::TaskInfo.new(nil,nil,nil,nil,nil,nil, status_list.map {|st| c::JobInfo.new(nil, st) })
+          assert_equal expected_count, task.failure_count
+        end
+      end
 
-  end
-end
+    end   # class TestJob
+
+  end   # module StreamingLoad
+end   # module Bricolage

--- a/test/streamingload/test_job.rb
+++ b/test/streamingload/test_job.rb
@@ -16,7 +16,7 @@ module Bricolage
     class TestJob < Test::Unit::TestCase
 
       test "execute_task" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [1, 1], [1, 2]
@@ -24,7 +24,7 @@ module Bricolage
             [1, 's3://data-bucket/testschema.desttable/0001.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp],
             [2, 's3://data-bucket/testschema.desttable/0002.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 1, force: false, logger: ctx.logger)
+          job = new_job(task_id: 1, force: false)
           job.execute_task
 
           assert_equal [
@@ -42,7 +42,7 @@ module Bricolage
       end
 
       test "execute_task (with work table)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.with_work_table', 'testschema', 'with_work_table', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -50,7 +50,7 @@ module Bricolage
             [1001, 's3://data-bucket/testschema.with_work_table/0001.json.gz', 1024, 'testschema.with_work_table', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.with_work_table/0002.json.gz', 1024, 'testschema.with_work_table', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           job.execute_task
 
           assert_equal [
@@ -70,11 +70,11 @@ module Bricolage
       end
 
       test "execute_task (disabled)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, true]
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 1, force: false, logger: ctx.logger)
+          job = new_job(task_id: 1, force: false)
           assert_raise(JobDefered) {
             job.execute_task
           }
@@ -84,7 +84,7 @@ module Bricolage
       end
 
       test "execute_task (duplicated)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_jobs',
@@ -92,7 +92,7 @@ module Bricolage
             [2, 1, 'localhost-1234', 'success', current_timestamp, current_timestamp, ''],
             [3, 1, 'localhost-1234', 'duplicated', current_timestamp, current_timestamp, '']
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 1, force: false, logger: ctx.logger)
+          job = new_job(task_id: 1, force: false)
           assert_raise(JobDuplicated) {
             job.execute_task
           }
@@ -100,7 +100,7 @@ module Bricolage
       end
 
       test "execute_task (duplicated but forced)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -108,7 +108,7 @@ module Bricolage
             [1001, 's3://data-bucket/testschema.desttable/0001.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.desttable/0002.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: true, logger: ctx.logger)
+          job = new_job(task_id: 11, force: true)
           job.execute_task
 
           assert_equal [
@@ -127,7 +127,7 @@ module Bricolage
       end
 
       test "execute_task (load fails / first time)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -135,7 +135,7 @@ module Bricolage
             [1001, 's3://data-bucket/testschema.desttable/0001.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.desttable/0002.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           assert_raise(JobFailure) {
             job.execute_task
           }
@@ -153,7 +153,7 @@ module Bricolage
       end
 
       test "execute_task (load fails / nth time)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -164,7 +164,7 @@ module Bricolage
             [101, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'query failed'],
             [102, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'query failed']
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           assert_raise(JobFailure) {
             job.execute_task
           }
@@ -183,7 +183,7 @@ module Bricolage
       end
 
       test "execute_task (too many retry)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -197,7 +197,7 @@ module Bricolage
             [104, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'retry#3 query failed'],
             [105, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'retry#4 query failed']
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           assert_raise(JobCancelled) {
             job.execute_task
           }
@@ -216,7 +216,7 @@ module Bricolage
       end
 
       test "execute_task (job error)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.job_error', 'testschema', 'job_error', 100, 1800, false]
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
@@ -224,7 +224,7 @@ module Bricolage
             [1001, 's3://data-bucket/testschema.job_error/0001.json.gz', 1024, 'testschema.job_error', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.job_error/0002.json.gz', 1024, 'testschema.job_error', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           assert_raise(JobError) {
             job.execute_task
           }
@@ -242,15 +242,15 @@ module Bricolage
       end
 
       test "execute_task (unexpected error)" do
-        setup_context {|ctx, ctl_ds, db|
+        setup_context {|db|
           db.insert_into 'strload_tables', [1, 'testschema.unexpected_error', 'testschema', 'unexpected_error', 100, 1800, false]
-          db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, sql('current_timestamp')]
+          db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
             [1001, 's3://data-bucket/testschema.unexpected_error/0001.json.gz', 1024, 'testschema.unexpected_error', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.unexpected_error/0002.json.gz', 1024, 'testschema.unexpected_error', 'mmmm', current_timestamp, current_timestamp]
 
-          job = Job.new(context: ctx, ctl_ds: ctl_ds, task_id: 11, force: false, logger: ctx.logger)
+          job = new_job(task_id: 11, force: false)
           assert_raise(JobError) {
             job.execute_task
           }
@@ -267,14 +267,76 @@ module Bricolage
         }
       end
 
+      test "execute_task (unknown status, really=success)" do
+        setup_context {|db|
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
+          db.insert_into 'strload_jobs',
+            [101, 11, 'localhost-1234', 'unknown', current_timestamp, current_timestamp, 'data connection failed']
+          @data_ds.provide_job_status 101, true
+
+          job = new_job(task_id: 11, force: false)
+          assert_raise(JobDuplicated) {
+            job.execute_task
+          }
+
+          job_row = db.query_row("select * from strload_jobs where job_id = 101")
+          assert_equal 'success', job_row['status']
+        }
+      end
+
+      test "execute_task (unknown status, really=failure)" do
+        setup_context {|db|
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
+          db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
+          db.insert_into 'strload_objects',
+            [1001, 's3://data-bucket/testschema.desttable/0001.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp],
+            [1002, 's3://data-bucket/testschema.desttable/0002.json.gz', 1024, 'testschema.desttable', 'mmmm', current_timestamp, current_timestamp]
+          db.insert_into 'strload_jobs',
+            [101, 11, 'localhost-1234', 'unknown', current_timestamp, current_timestamp, 'data connection failed']
+          @data_ds.provide_job_status 101, false
+
+          job = new_job(task_id: 11, force: false)
+          job.execute_task
+
+          assert_equal [
+            "begin transaction;",
+            "copy testschema.desttable from '#{job.manifest.url}' credentials 'cccc' manifest statupdate false compupdate false json 'auto' gzip timeformat 'auto' dateformat 'auto' acceptanydate acceptinvchars ' ' truncatecolumns trimblanks ;",
+            "insert into strload_load_logs (job_id, finish_time) values (#{job.job_id}, current_timestamp)",
+            "commit;"
+          ], job.data_ds.sql_list
+
+          job_row = db.query_row("select * from strload_jobs where job_id = 101")
+          assert_equal 'failure', job_row['status']
+
+          job_row = db.query_row("select * from strload_jobs where job_id = #{job.job_id}")
+          assert_equal 11, job_row['task_id'].to_i
+          assert_equal job.process_id, job_row['process_id']
+          assert_equal 'success', job_row['status']
+        }
+      end
+
       def setup_context(verbose: false)
-        ctx = Context.for_application('.', environment: 'test', logger: (verbose ? nil : NullLogger.new))
-        ctl_ds = ctx.get_data_source('sql', 'dwhctl')
-        ctl_ds.open {|conn|
+        @ctx = Context.for_application('.', environment: 'test', logger: (verbose ? nil : NullLogger.new))
+        @ctl_ds = @ctx.get_data_source('sql', 'dwhctl')
+        @data_ds = @ctx.get_data_source('sql', 'db_data_mock')
+        @ctl_ds.open {|conn|
           client = SQLClient.new(conn)
           clear_all_tables(client)
-          yield ctx, ctl_ds, client
+          yield client
         }
+      end
+
+      def new_job(task_id:, force:)
+        Job.new(
+          context: @ctx,
+          ctl_ds: @ctl_ds,
+          data_ds: @data_ds,
+          logger: @ctx.logger,
+          task_id: task_id,
+          force: force
+        )
       end
 
       # FIXME: database cleaner
@@ -373,6 +435,7 @@ module Bricolage
           @fail_pattern = fail_pattern ? Regexp.compile(fail_pattern) : nil
           @error_pattern = error_pattern ? Regexp.compile(error_pattern) : nil
           @exception_pattern = exception_pattern ? Regexp.compile(exception_pattern) : nil
+          @job_status = {}
         end
 
         attr_reader :sql_list
@@ -400,9 +463,28 @@ module Bricolage
           end
         end
 
+        def provide_job_status(job_id, succeeded)
+          @job_status[job_id] = succeeded
+        end
+
+        def job_succeeded?(job_id)
+          raise "job status unregistered: job_id=#{job_id}" unless @job_status.key?(job_id)
+          @job_status[job_id]
+        end
+
         class Connection
           def initialize(ds)
             @ds = ds
+          end
+
+          def query_value(sql)
+            case sql
+            when /\bstrload_load_logs where job_id = (\d+)/
+              job_id = $1.to_i
+              @ds.job_succeeded?(job_id) ? 1 : 0
+            else
+              raise "unknown query: #{sql}"
+            end
           end
 
           def execute(sql)


### PR DESCRIPTION
Redshiftへのコネクションが切れてロードステータスが不明になったとき、そのステータスをunknownとして記録しておき、あとでunknownステータスに遭遇したときにRedshiftのログテーブルを読んでstrload_jobsを補完する。
