### PR TITLE
[CHANGE] Adds task_id column to strload_load_log

### DIFF
--- a/strload_load_logs.ct
+++ b/strload_load_logs.ct
@@ -5,6 +5,7 @@
 */
 create table $dest_table
 ( job_id bigint encode raw
+, task_id bigint encode zstd
 , finish_time timestamp encode delta
 )
 distkey (job_id)

--- a/test/streamingload/test_job.rb
+++ b/test/streamingload/test_job.rb
@@ -30,7 +30,7 @@ module Bricolage
           assert_equal [
             "begin transaction;",
             "copy testschema.desttable from '#{job.manifest.url}' credentials 'cccc' manifest statupdate false compupdate false json 'auto' gzip timeformat 'auto' dateformat 'auto' acceptanydate acceptinvchars ' ' truncatecolumns trimblanks ;",
-            "insert into strload_load_logs (job_id, finish_time) values (#{job.job_id}, current_timestamp)",
+            "insert into strload_load_logs (task_id, job_id, finish_time) values (1, #{job.job_id}, current_timestamp)",
             "commit;"
           ], job.data_ds.sql_list
 
@@ -58,7 +58,7 @@ module Bricolage
             "delete from testschema.with_work_table_wk",
             "copy testschema.with_work_table_wk from '#{job.manifest.url}' credentials 'cccc' manifest statupdate false compupdate false json 'auto' gzip timeformat 'auto' dateformat 'auto' acceptanydate acceptinvchars ' ' truncatecolumns trimblanks ;",
             "insert into testschema.with_work_table select * from testschema.with_work_table_wk;\n",
-            "insert into strload_load_logs (job_id, finish_time) values (#{job.job_id}, current_timestamp)",
+            "insert into strload_load_logs (task_id, job_id, finish_time) values (11, #{job.job_id}, current_timestamp)",
             "truncate testschema.with_work_table_wk;"
           ], job.data_ds.sql_list
 
@@ -114,7 +114,7 @@ module Bricolage
           assert_equal [
             "begin transaction;",
             "copy testschema.desttable from '#{job.manifest.url}' credentials 'cccc' manifest statupdate false compupdate false json 'auto' gzip timeformat 'auto' dateformat 'auto' acceptanydate acceptinvchars ' ' truncatecolumns trimblanks ;",
-            "insert into strload_load_logs (job_id, finish_time) values (#{job.job_id}, current_timestamp)",
+            "insert into strload_load_logs (task_id, job_id, finish_time) values (11, #{job.job_id}, current_timestamp)",
             "commit;"
           ], job.data_ds.sql_list
 
@@ -303,7 +303,7 @@ module Bricolage
           assert_equal [
             "begin transaction;",
             "copy testschema.desttable from '#{job.manifest.url}' credentials 'cccc' manifest statupdate false compupdate false json 'auto' gzip timeformat 'auto' dateformat 'auto' acceptanydate acceptinvchars ' ' truncatecolumns trimblanks ;",
-            "insert into strload_load_logs (job_id, finish_time) values (#{job.job_id}, current_timestamp)",
+            "insert into strload_load_logs (task_id, job_id, finish_time) values (11, #{job.job_id}, current_timestamp)",
             "commit;"
           ], job.data_ds.sql_list
 


### PR DESCRIPTION
strloadはロードが完了したことを確実に記録するためにRedshift側にロードログを持っていますが、そのロードログにtask_idカラムを追加します。

これまで保存していた情報はjob_id（とfinish_time）だけで、実際にstrloadで使っているのはjob_idだけなんですが、クラスター移行のときに使うロード再現処理（別のクラスターでロード処理だけリプレイするもの）ではtask_idがあるとかなり楽になるため、追加します。

CC @bricolages/all 