### PR TITLE
Reduces retry count

### DIFF
--- a/config/test/database.yml
+++ b/config/test/database.yml
@@ -12,6 +12,7 @@ db_data_mock:
   fail_pattern: sql_fails
   error_pattern: job_error
   exception_pattern: unexpected_error
+  load_error_pattern: load_error
 
 s3_ctl_mock:
   type: s3_mock

--- a/lib/bricolage/streamingload/job.rb
+++ b/lib/bricolage/streamingload/job.rb
@@ -69,7 +69,7 @@ module Bricolage
         return true
       end
 
-      MAX_RETRY = 5
+      MAX_RETRY = 2
 
       def execute_task
         @process_id = "#{Socket.gethostname}-#{$$}"

--- a/lib/bricolage/streamingload/job.rb
+++ b/lib/bricolage/streamingload/job.rb
@@ -241,6 +241,12 @@ module Bricolage
               ;
           EndSQL
           @logger.info "load succeeded: #{manifest.url}"
+        rescue JobFailure => ex
+          if /stl_load_errors/ =~ ex.message
+            # We cannot resolve this load error by retry, give up now.
+            raise JobError, ex.message
+          end
+          raise
         end
 
         def write_load_log(log)

--- a/test/streamingload/test_job.rb
+++ b/test/streamingload/test_job.rb
@@ -161,8 +161,7 @@ module Bricolage
             [1001, 's3://data-bucket/testschema.sql_fails/0001.json.gz', 1024, 'testschema.sql_fails', 'mmmm', current_timestamp, current_timestamp],
             [1002, 's3://data-bucket/testschema.sql_fails/0002.json.gz', 1024, 'testschema.sql_fails', 'mmmm', current_timestamp, current_timestamp]
           db.insert_into 'strload_jobs',
-            [101, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'query failed'],
-            [102, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'query failed']
+            [101, 11, 'localhost-1234', 'failure', current_timestamp, current_timestamp, 'query failed']
 
           job = new_job(task_id: 11, force: false)
           assert_raise(JobFailure) {
@@ -178,7 +177,7 @@ module Bricolage
           assert_equal 11, job_row['task_id'].to_i
           assert_equal job.process_id, job_row['process_id']
           assert_equal 'failure', job_row['status']
-          assert(/retry\#2/ =~ job_row['message'])
+          assert(/retry\#1/ =~ job_row['message'])
         }
       end
 


### PR DESCRIPTION
ロードエラーが起きたときのリトライ回数を全体的に減らします。

- デフォルトのリトライ回数を5回から2回に削減（最初の1回はこれに含んでいないので、試行回数だと6回→3回）。
- stl_load_errorsにログが残るロードエラーは何度やっても失敗することがわかっているのでリトライしない。

@bricolages/all レビューお願いします。