### PR TITLE
Retry also error tasks, not only failure tasks

### DIFF
--- a/lib/bricolage/streamingload/job.rb
+++ b/lib/bricolage/streamingload/job.rb
@@ -63,7 +63,7 @@ module Bricolage
         return false
       rescue JobError => ex
         @logger.error ex.message
-        return true
+        return false
       rescue Exception => ex
         @logger.exception ex
         return true


### PR DESCRIPTION
 Error tasks are assumed as "non-retriable" e.g. DB login error, but some of them are really able to be resolved by retrying on ECS environment.  Retrying is not expensive (and human operation is relatively expensive), we will retry on all failures and errors.