### PR TITLE
Introduces Sentry error reporting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,51 @@
 PATH
   remote: .
   specs:
-    bricolage-streamingload (0.15.2)
+    bricolage-streamingload (0.16.1)
       aws-sdk-s3 (~> 1.8)
       aws-sdk-sqs (~> 1.3)
-      bricolage (>= 5.29.2)
+      bricolage (~> 5.30)
       pg (~> 0.18.0)
+      sentry-raven (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.0.1)
-    aws-partitions (1.102.0)
-    aws-sdk-core (3.25.0)
-      aws-eventstream (~> 1.0)
-      aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.351.0)
+    aws-sdk-core (3.104.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.7.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.17.1)
-      aws-sdk-core (~> 3, >= 3.21.2)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.75.0)
+      aws-sdk-core (~> 3, >= 3.104.1)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-sns (1.3.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-sqs (1.4.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.3)
-    bricolage (5.29.2)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sns (1.28.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-sqs (1.30.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
+    bricolage (5.30.0)
       aws-sdk-s3 (~> 1)
       aws-sdk-sns (~> 1)
       pg (~> 0.18.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     jmespath (1.4.0)
+    multipart-post (2.1.1)
     pg (0.18.4)
     power_assert (1.1.3)
     rake (12.3.1)
+    sentry-raven (3.0.0)
+      faraday (>= 1.0)
     test-unit (3.2.8)
       power_assert
 
@@ -51,4 +58,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Bricolage Streaming Load Release Note
 
+## version 0.16.1
+
+- [fix] Stop retrying after 2 times retried (total 3 trial).
+
 ## version 0.16.0
 
 - [new] Retry for also error tasks, not only failure tasks.

--- a/bricolage-streamingload.gemspec
+++ b/bricolage-streamingload.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.3.0'
-  s.add_dependency 'bricolage', '>= 5.29.2'
+  s.add_dependency 'bricolage', '~> 5.30'
   s.add_dependency 'pg', '~> 0.18.0'
   s.add_dependency 'aws-sdk-s3', '~> 1.8'
   s.add_dependency 'aws-sdk-sqs', '~> 1.3'
+  s.add_dependency 'sentry-raven', '~> 3.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'test-unit'
 end

--- a/lib/bricolage/streamingload/dispatcher.rb
+++ b/lib/bricolage/streamingload/dispatcher.rb
@@ -10,8 +10,9 @@ require 'bricolage/streamingload/chunkbuffer'
 require 'bricolage/streamingload/loadtasklogger'
 require 'bricolage/streamingload/alertinglogger'
 require 'yaml'
-require 'optparse'
 require 'fileutils'
+require 'raven'
+require 'optparse'
 
 module Bricolage
 
@@ -20,6 +21,12 @@ module Bricolage
     class Dispatcher < SQSDataSource::MessageHandler
 
       def Dispatcher.main
+        Raven.capture {
+          _main
+        }
+      end
+
+      def Dispatcher._main
         opts = DispatcherOptions.new(ARGV)
         opts.parse
         unless opts.rest_arguments.size == 1

--- a/lib/bricolage/streamingload/version.rb
+++ b/lib/bricolage/streamingload/version.rb
@@ -1,5 +1,5 @@
 module Bricolage
   module StreamingLoad
-    VERSION = '0.16.0'
+    VERSION = '0.16.1'
   end
 end

--- a/test/streamingload/test_dispatcher.rb
+++ b/test/streamingload/test_dispatcher.rb
@@ -68,7 +68,7 @@ module Bricolage
           conn.update("truncate strload_objects")
           conn.update("truncate strload_task_objects")
           conn.update("truncate strload_tasks")
-          conn.update("insert into strload_tables values (1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false)")
+          conn.update("insert into strload_tables values (1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix')")
         }
         dispatcher.event_loop
 
@@ -167,9 +167,9 @@ module Bricolage
           conn.update("truncate strload_objects")
           conn.update("truncate strload_task_objects")
           conn.update("truncate strload_tasks")
-          conn.update("insert into strload_tables values (1, 'testschema.aaa', 'testschema', 'aaa', 100, 1800, false)")
-          conn.update("insert into strload_tables values (2, 'testschema.bbb', 'testschema', 'bbb', 100, 1800, false)")
-          conn.update("insert into strload_tables values (3, 'testschema.ccc', 'testschema', 'ccc', 100, 1800, false)")
+          conn.update("insert into strload_tables values (1, 'testschema.aaa', 'testschema', 'aaa', 100, 1800, false, 'test-bucket', 'test-prefix')")
+          conn.update("insert into strload_tables values (2, 'testschema.bbb', 'testschema', 'bbb', 100, 1800, false, 'test-bucket', 'test-prefix')")
+          conn.update("insert into strload_tables values (3, 'testschema.ccc', 'testschema', 'ccc', 100, 1800, false, 'test-bucket', 'test-prefix')")
         }
         dispatcher.event_loop
 

--- a/test/streamingload/test_job.rb
+++ b/test/streamingload/test_job.rb
@@ -17,7 +17,7 @@ module Bricolage
 
       test "execute_task" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [1, 1], [1, 2]
           db.insert_into 'strload_objects',
@@ -43,7 +43,7 @@ module Bricolage
 
       test "execute_task (with work table)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.with_work_table', 'testschema', 'with_work_table', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.with_work_table', 'testschema', 'with_work_table', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -71,7 +71,7 @@ module Bricolage
 
       test "execute_task (disabled)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, true]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, true, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
 
           job = new_job(task_id: 1, force: false)
@@ -85,7 +85,7 @@ module Bricolage
 
       test "execute_task (duplicated)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [1, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_jobs',
             [1, 1, 'localhost-1234', 'failure', current_timestamp, current_timestamp, ''],
@@ -101,7 +101,7 @@ module Bricolage
 
       test "execute_task (duplicated but forced)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -128,7 +128,7 @@ module Bricolage
 
       test "execute_task (load fails / first time)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -154,7 +154,7 @@ module Bricolage
 
       test "execute_task (load fails / nth time)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -183,7 +183,7 @@ module Bricolage
 
       test "execute_task (too many retry)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.sql_fails', 'testschema', 'sql_fails', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -216,7 +216,7 @@ module Bricolage
 
       test "execute_task (job error)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.job_error', 'testschema', 'job_error', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.job_error', 'testschema', 'job_error', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -242,7 +242,7 @@ module Bricolage
 
       test "execute_task (unexpected error)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.unexpected_error', 'testschema', 'unexpected_error', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.unexpected_error', 'testschema', 'unexpected_error', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -268,7 +268,7 @@ module Bricolage
 
       test "execute_task (load error)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.load_error', 'testschema', 'load_error', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.load_error', 'testschema', 'load_error', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',
@@ -295,7 +295,7 @@ module Bricolage
 
       test "execute_task (unknown status, really=success)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_jobs',
             [101, 11, 'localhost-1234', 'unknown', current_timestamp, current_timestamp, 'data connection failed']
@@ -313,7 +313,7 @@ module Bricolage
 
       test "execute_task (unknown status, really=failure)" do
         setup_context {|db|
-          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false]
+          db.insert_into 'strload_tables', [1, 'testschema.desttable', 'testschema', 'desttable', 100, 1800, false, 'test-bucket', 'test-prefix']
           db.insert_into 'strload_tasks', [11, 'streaming_load_v3', 1, current_timestamp]
           db.insert_into 'strload_task_objects', [11, 1001], [11, 1002]
           db.insert_into 'strload_objects',


### PR DESCRIPTION
Current error reporting using Amazon SNS does not work if the strload process cannot get any AWS credentials, we introduces Sentry for the same sake.  Sentry (Raven module) does nothing if no SENTRY_DNS environment variable is given, this is backward-compatible.